### PR TITLE
disable 'Accept-Encoding: br'，解决报错并下载成二进制 .note 文件的问题

### DIFF
--- a/pull.py
+++ b/pull.py
@@ -318,7 +318,7 @@ class YoudaoNoteApi(object):
             'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) '
                           'Chrome/100.0.4896.88 Safari/537.36',
             'Accept': '*/*',
-            'Accept-Encoding': 'gzip, deflate, br',
+            'Accept-Encoding': 'gzip, deflate',
             'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
             'sec-ch-ua': '" Not A;Brand";v="99", "Chromium";v="100", "Google Chrome";v="100"',
             'sec-ch-ua-mobile': '?0',


### PR DESCRIPTION
requests 默认不支持解码 br brotli 压缩的回包，会导致保存成无法打开的二进制 .note 文件