### PR TITLE
feat: 支持文档markdown元数据导出, 支持图片链接下载多次重试

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ python pull.py   # Windows
 
 ![2020-06-23-145839](https://deppwang.oss-cn-beijing.aliyuncs.com/blog/2020-08-04-073242.png)
 
+
 ### 三、多次导出
 
 多次导出时，同样使用以下命令：
@@ -179,6 +180,40 @@ python pull.py   # Windows
 根据有道云笔记文件最后修改时间是否大于本地文件最后修改时间来判断是否需要更新。再次导出时，只会导出有道云笔记上次导出后新增、修改或未导出的笔记，不会覆盖本地已经修改的文件。**但有道云笔记和本地不要同时修改同一个文件，这样可能会导致本地修改丢失**！
 
 更新时，会重新下载文件并覆盖原文件，图片也会重新下载。
+
+### 额外参数
+
+```bash
+python pull.py  --frontmatter  --retryurl
+```
+
+#### 支持导出文档元数据信息 
+
+有道笔记里记录了文章的创建日期, 修改日期, 文件大小等参数, 尤其是日期信息, 可以快速得知文档背后的故事. 直接导出为markdown后丢失了这部分信息, 对于使用有道云多年的用户而言比较可惜.
+
+支持增加参数 `--frontmatter`, 在markdown里增加元数据信息 `frontmatter`. 在原文档可以直接查看 `frontmatter`, 经过标准的markdown应用渲染后则无法看到, 不影响阅读.
+
+> 关于frontmatter的介绍: https://frontmatter.codes/docs/markdown
+
+支持对已经备份的文档再次运行该命令, 增加元数据信息.  同时也支持多次运行, 不会导致数据冗余. 
+
+```bash
+python pull.py --frontmatter
+```
+
+可以查看导出的例子
+
+[markdown-frontend](./test/test-frontmatter.md)
+
+
+#### 支持对下载链接进行再次重试
+
+对于历经几年数GB的youdao云笔记, 图片和链接的地址可能成千上万, 非常容易出现某些文档下载成功了, 但是图片却处理失败的情况.  增加参数`--retryurl`, 支持多次运行, 对未下载成功的图片和文档进行再次重试. 
+
+```bash
+python pull.py --retryurl
+```
+
 
 ## 注意事项
 

--- a/pull.py
+++ b/pull.py
@@ -11,7 +11,10 @@ import traceback
 import xml.etree.ElementTree as ET
 from enum import Enum
 from urllib.parse import urlparse
+from datetime import datetime
 
+import yaml
+import frontmatter
 import requests
 
 __author__ = 'Depp Wang (deppwxq@gmail.com)'
@@ -418,6 +421,14 @@ class YoudaoNoteApi(object):
         return self.http_post(url, data=data)
 
 
+class AdditionalArgs(object):
+    """
+    支持简单的命令行配置
+    """
+    PATCH_MARKDOWN_FRONT_MATTER  = False
+    RETRY_DOWNLOAD_MARKDOWN_URL  = False
+
+
 class YoudaoNotePull(object):
     """
     有道云笔记 Pull 封装
@@ -473,7 +484,7 @@ class YoudaoNotePull(object):
                 self.pull_dir_by_id_recursively(id, sub_dir)
             else:
                 modify_time = file_entry['modifyTimeForSort']
-                self._add_or_update_file(id, name, local_dir, modify_time)
+                self._add_or_update_file(id, name, local_dir, modify_time, entry)
 
     def _covert_config(self, config_path=None) -> (dict, str):
         """
@@ -535,7 +546,26 @@ class YoudaoNotePull(object):
 
         return '', '有道云笔记指定顶层目录不存在'
 
-    def _add_or_update_file(self, file_id, file_name, local_dir, modify_time):
+    def _additional_file_action(self, local_file_path, entry):
+        """
+        对本地文件额外操作, 支持多次运行重试.
+
+        Args:
+            local_file_path (_type_): _description_
+            entry (_type_): _description_
+        """
+        if not os.path.exists(local_file_path):
+            return
+
+        # 添加 markdown frontmatter 参数
+        if AdditionalArgs.PATCH_MARKDOWN_FRONT_MATTER:
+            self._patch_markdown_front_matter(local_file_path, entry)
+        
+        # 额外重试下载失败的图片和附件链接 (失败的链接仍然保持youdao.com的标记, 可以直接重试)
+        if AdditionalArgs.RETRY_DOWNLOAD_MARKDOWN_URL:
+            self._migration_ydnote_url(local_file_path)
+
+    def _add_or_update_file(self, file_id, file_name, local_dir, modify_time, entry):
         """
         新增或更新文件
         :param file_id:
@@ -554,13 +584,14 @@ class YoudaoNotePull(object):
         # 如果有有道云笔记是「note」类型，则提示类型
         tip = '，云笔记原格式为 note' if is_note else ''
         file_action = self._get_file_action(local_file_path, modify_time)
+        self._additional_file_action(local_file_path, entry)
         if file_action == FileActionEnum.CONTINUE:
             return
         if file_action == FileActionEnum.UPDATE:
             # 考虑到使用 f.write() 直接覆盖原文件，在 Windows 下报错（WinError 183），先将其删除
             os.remove(local_file_path)
         try:
-            self._pull_file(file_id, original_file_path, local_file_path, is_note, youdao_file_suffix)
+            self._pull_file(file_id, original_file_path, local_file_path, is_note, youdao_file_suffix, entry)
             print('{}「{}」{}'.format(file_action.value, local_file_path, tip))
         except Exception as error:
             print('{}「{}」失败！请检查文件！错误提示：{}'.format(file_action.value, original_file_path, format(error)))
@@ -583,7 +614,7 @@ class YoudaoNotePull(object):
             is_note = True if content == b"<?xml" else False
         return is_note
 
-    def _pull_file(self, file_id, file_path, local_file_path, is_note, youdao_file_suffix):
+    def _pull_file(self, file_id, file_path, local_file_path, is_note, youdao_file_suffix, entry):
         """
         下载文件
         :param file_id:
@@ -611,6 +642,49 @@ class YoudaoNotePull(object):
         # 3、迁移文本文件里面的有道云笔记链接
         if is_note or youdao_file_suffix == MARKDOWN_SUFFIX:
             self._migration_ydnote_url(local_file_path)
+        
+        # 4、增加markdown frontmatter信息
+        if AdditionalArgs.PATCH_MARKDOWN_FRONT_MATTER:
+            self._patch_markdown_front_matter(local_file_path, entry)
+
+    def _patch_markdown_front_matter(self, local_file_path, file_params):
+        """
+        将有道云笔记的参数做为markdown的frontmatter记录, 主要用于记录创建时间和修改时间.
+
+        Args:
+            local_file_path (_type_): _description_
+            file_params (_type_): _description_
+        """
+        
+        if not local_file_path.endswith(".md"):
+            print(f"非markdown文件, 不需要处理markdown frontmatter: {local_file_path}")
+            return
+        
+        file_entry =  file_params["fileEntry"]
+        with open(local_file_path, "r") as f:
+            try:
+                fm = frontmatter.load(f)
+            except yaml.scanner.ScannerError as ex:
+                print(f"识别 markdown frontmatter错误, 忽略. file {f} except: {ex}")
+                return
+            remote_modified_time = file_entry["modifyTimeForSort"]
+            stored_update_time = fm.metadata.get("noteMeta", {}).get("modifyTimeForSort", -1)
+            if stored_update_time >= remote_modified_time:
+                return
+            fm.metadata["noteMeta"] = {
+                "id": file_entry["id"],
+                "name":  file_entry["name"],
+                "parentId":  file_entry["parentId"],
+                "version": file_entry["version"],
+                "fileSize": file_entry["fileSize"],
+                "checksum": file_entry["checksum"],
+                "createTimeForSort":  file_entry["createTimeForSort"],
+                "modifyTimeForSort":  file_entry["modifyTimeForSort"]
+            }
+            fm.metadata["createTime"] = datetime.fromtimestamp(file_entry["createTimeForSort"]).isoformat()
+            fm.metadata["modifyTime"] = datetime.fromtimestamp(file_entry["modifyTimeForSort"]).isoformat()
+            print(f"update metadata: {file_entry['name']} modified at {fm.metadata['modifyTime']}")
+        frontmatter.dump(fm, local_file_path)           
 
     def _get_file_action(self, local_file_path, modify_time) -> Enum:
         """
@@ -646,6 +720,13 @@ class YoudaoNotePull(object):
         :param file_path:
         :return:
         """
+        
+        # 有道笔记后来支持直接上传excel等附件, 这类文件不需要迁移url
+        # 不然下方会报错 /youdao-backup/abc.xlsx 'utf-8' codec can't decode byte 0x87 in position 10: invalid start byte
+        if not file_path.endswith(".md"):
+            print(f"非markdown文件, 不需要处理markdown链接: {file_path}")
+            return
+        
         with open(file_path, 'rb') as f:
             content = f.read().decode('utf-8')
 
@@ -661,6 +742,7 @@ class YoudaoNotePull(object):
             #将 image_path 路径中 images 之前的路径去掉，只保留以 images 开头的之后的路径
             if self.is_relative_path:
                 image_path = image_path[image_path.find(IMAGES):]
+            # 其实 image 与附件的正则表达式差不多, 不过这里先处理了图片, 就不会继续尝试附件下载了
             content = content.replace(image_url, image_path)
 
         # 附件
@@ -711,7 +793,12 @@ class YoudaoNotePull(object):
         :param attach_name:
         :return:  path
         """
-        try:
+        
+        # patch for: requests.exceptions.MissingSchema: Invalid URL '//note.youdao.com/src/xxxx
+        if url.startswith("//note.youdao.com"):
+            url = "https:" + url
+
+        try:            
             response = self.youdaonote_api.http_get(url)
         except requests.exceptions.ProxyError as err:
             error_msg = '网络错误，「{}」下载失败。错误提示：{}'.format(url, format(err))
@@ -721,8 +808,7 @@ class YoudaoNotePull(object):
         content_type = response.headers.get('Content-Type')
         file_type = '附件' if attach_name else '图片'
         if response.status_code != 200 or not content_type:
-            error_msg = '下载「{}」失败！{}可能已失效，可浏览器登录有道云笔记后，查看{}是否能正常加载'.format(url, file_type,
-                                                                           file_type)
+            error_msg = f'下载「{url}」失败！{file_type}可能已失效，可浏览器登录有道云笔记后，查看{file_type}是否能正常加载: statusCode: {response.status_code}, content_type: {content_type}'
             print(error_msg)
             return ''
 
@@ -779,6 +865,15 @@ class YoudaoNotePull(object):
 
 if __name__ == '__main__':
     start_time = int(time.time())
+    
+    # 简化版命令行解析, 支持导出markdown frontmatter, 支持重试文章中的图片和附件链接
+    print(f"sys args: {sys.argv}")
+    if "--frontmatter" in sys.argv:
+        AdditionalArgs.PATCH_MARKDOWN_FRONT_MATTER = True
+    if "--retryurl" in sys.argv:
+        AdditionalArgs.RETRY_DOWNLOAD_MARKDOWN_URL = True
+    print(f"Additional Args: {AdditionalArgs.PATCH_MARKDOWN_FRONT_MATTER}, {AdditionalArgs.RETRY_DOWNLOAD_MARKDOWN_URL}")
+    
     try:
         youdaonote_pull = YoudaoNotePull()
         ydnote_dir_id, error_msg = youdaonote_pull.get_ydnote_dir_id()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-requests==2.22.0
+requests~=2.30.0
 markdownify==0.5.1
 Brotli==1.0.9
+python-frontmatter==1.0.0

--- a/test/test-frontmatter.md
+++ b/test/test-frontmatter.md
@@ -1,0 +1,15 @@
+---
+createTime: '2023-06-09T16:41:15'
+modifyTime: '2023-06-09T16:42:40'
+noteMeta:
+  checksum: 9F532427125C403399DB25437102E5A1
+  createTimeForSort: 1686300075
+  fileSize: 202797
+  id: WEBf5395da6d8c6a5cc7914ce83a983fake
+  modifyTimeForSort: 1686300160
+  name: 测试下载迁移文档元数据.note
+  parentId: WEB16be459ab4f4c19254c79c689806fake
+  version: 222043
+---
+
+测试下载迁移文档元数据


### PR DESCRIPTION
1. 有道笔记里记录了文章的创建日期, 修改日期, 文件大小等参数, 尤其是日期信息, 可以快速得知文档背后的故事. 直接导出为markdown后丢失了这部分信息, 对于使用有道云多年的用户而言比较可惜. 使用markdown frontmatter, 支持保存元数据信息.

2.  repo并不支持单独对链接进行重试,  对于历经几年数GB的youdao云笔记, 图片和链接的地址可能成千上万, 非常容易出现某些文档下载成功了, 但是图片却处理失败的情况.  增加参数`--retryurl`, 支持多次运行, 对未下载成功的图片和文档进行再次重试. 

使用额外的命令行参数, 支持多次重复运行, 不添加参数的话不修改原来代码的逻辑
```
python pull.py --frontmatter --retryurl
```

另外顺手修复了执行过程中的一些小bug, 比如excel文档附件不需要转换等, 增加兼容性