### PR TITLE
fix:下载的图片文件格式统一变成了octet-stream

### DIFF
--- a/pull.py
+++ b/pull.py
@@ -10,6 +10,7 @@ import time
 import traceback
 import xml.etree.ElementTree as ET
 from enum import Enum
+from urllib import parse
 from urllib.parse import urlparse
 
 import requests

--- a/pull.py
+++ b/pull.py
@@ -751,7 +751,7 @@ class YoudaoNotePull(object):
         #file_name = ''.join([file_basename, file_suffix])
         #请求后的真实的URL中才有东西
         realUrl = response.url
-        file_name = parse.parse_qs(urlparse(realUrl).query)['download'][0]
+        file_name =file_basename+parse.parse_qs(urlparse(realUrl).query)['download'][0]
         local_file_path = os.path.join(local_file_dir, file_name).replace('\\', '/')
         try:
             with open(local_file_path, 'wb') as f:

--- a/pull.py
+++ b/pull.py
@@ -748,7 +748,10 @@ class YoudaoNotePull(object):
         if not os.path.exists(local_file_dir):
             os.mkdir(local_file_dir)
         file_basename = os.path.basename(urlparse(url).path)
-        file_name = ''.join([file_basename, file_suffix])
+        #file_name = ''.join([file_basename, file_suffix])
+        #请求后的真实的URL中才有东西
+        realUrl = response.url
+        file_name = parse.parse_qs(urlparse(realUrl).query)['download'][0]
         local_file_path = os.path.join(local_file_dir, file_name).replace('\\', '/')
         try:
             with open(local_file_path, 'wb') as f:

--- a/pull.py
+++ b/pull.py
@@ -749,10 +749,13 @@ class YoudaoNotePull(object):
         if not os.path.exists(local_file_dir):
             os.mkdir(local_file_dir)
         file_basename = os.path.basename(urlparse(url).path)
-        #file_name = ''.join([file_basename, file_suffix])
         #请求后的真实的URL中才有东西
-        realUrl = response.url
-        file_name =file_basename+parse.parse_qs(urlparse(realUrl).query)['download'][0]
+        realUrl = parse.parse_qs(urlparse(response.url).query)
+        if realUrl:
+            # dict 不为空再去取 download
+            file_name = file_basename + realUrl['download'][0]
+        else:
+            file_name = ''.join([file_basename, file_suffix])
         local_file_path = os.path.join(local_file_dir, file_name).replace('\\', '/')
         try:
             with open(local_file_path, 'wb') as f:


### PR DESCRIPTION
有道云笔记下载图片的链接context-type成了octet-stream
从response中的URL中取得文件名
风险：不确定是否所有的图片下载都有该属性