### PR TITLE
更新requests版本解决在 python3.12.7以上找不到 urllib3 的问题

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.22.0
+requests==2.32.3
 markdownify==0.5.1
 Brotli==1.0.9
 win32-setctime==1.1.0


### PR DESCRIPTION
使用时发现 3.13，或 3.12.7 版本以上的 python 都会报错，经排查应该是 requests 版本问题，更新后一切功能正常。